### PR TITLE
[Suggestion] ci: only enable one OS by default, document windows platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,15 @@ jobs:
     strategy:
       matrix:
         # Select platform(s)
-        os: [ ubuntu-latest, macos-latest ]
+        os:
+          - ubuntu-latest
+          # If your application contains any OS-dependent logic (such as
+          # accesses to the filesystem or invocations of native libraries),
+          # you can enable further OS platforms here. Other than that, you may
+          # just leave them disabled to reduce energy usage and build time :)
+          # (Usually, windows builds are slower than ubuntu/macOS.)
+          #- macos-latest
+          #- windows-latest
         # Select compatible Smalltalk image(s)
         smalltalk: [ Squeak64-trunk, Squeak64-5.3, Squeak64-5.2 ]
     name: ${{ matrix.smalltalk }} on ${{ matrix.os }}


### PR DESCRIPTION
Reasoning: A vast majority of Squeak/Smalltalk applications are platform-independent anyway, causing a considerable overhead in tedious build times for all projects. By documenting but disabling other platforms by default, we leave relevant teams the possibility to easily opt-in to multi-platform builds but reduce build times and also energy usage by default. At the same time, we encourage them to discuss cross-platform requirements and implications with their customer.

In addition to the pros above, there would also be some cons:

- Teams might be unaware of cross-platform concerns (either a blessing or a curse?)
- Redundant builds may reveal flaky/nondeterministic tests (but in such cases, the association with a certain OS will often be misleading)

@fniephaus What do you think? :) /cc @kdauer